### PR TITLE
Update failed read check.

### DIFF
--- a/adafruit_us100.py
+++ b/adafruit_us100.py
@@ -40,6 +40,8 @@ Implementation Notes
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_US100.git"
 
+import time
+
 
 class US100:
     """Control a US-100 ultrasonic range sensor."""
@@ -51,34 +53,52 @@ class US100:
     def distance(self):
         """Return the distance measured by the sensor in cm.
         This is the function that will be called most often in user code.
-        If no signal is received, we'll throw a RuntimeError exception. This means
-        either the sensor was moving too fast to be pointing in the right
+        If no signal is received, return ``None``. This can happen when the
+        object in front of the sensor is too close, the wiring is incorrect or the
+        sensor is not found. If the signal received is not 2 bytes, return ``None``.
+        This means either the sensor was moving too fast to be pointing in the right
         direction to pick up the ultrasonic signal when it bounced back (less
         likely), or the object off of which the signal bounced is too far away
-        for the sensor to handle. In my experience, the sensor can detect
+        for the sensor to handle. In my experience, the sensor can not detect
         objects over 460 cm away.
         :return: Distance in centimeters.
         :rtype: float
         """
-        self._uart.write(bytes([0x55]))
-        data = self._uart.read(2)  # 2 bytes return for distance
-        if not data:
-            raise RuntimeError("Sensor not found. Check your wiring!")
+        for _ in range(2):  # Attempt to read twice.
+            self._uart.write(bytes([0x55]))
+            data = self._uart.read(2)  # 2 byte return for distance.
+            if data:  # If there is a reading, exit the loop.
+                break
+            time.sleep(0.1)  # You need to wait between readings, so delay is included.
+        else:
+            # Loop exited normally, so read failed twice.
+            # This can happen when the object in front of the sensor is too close, if the wiring
+            # is incorrect or the sensor is not found.
+            return None
 
         if len(data) != 2:
-            raise RuntimeError("Did not receive distance response")
+            return None
+
         dist = (data[1] + (data[0] << 8)) / 10
         return dist
 
     @property
     def temperature(self):
         """Return the on-chip temperature, in Celsius"""
-        self._uart.write(bytes([0x50]))
-        data = self._uart.read(1)  # 1 byte return for temp
-        if not data:
-            raise RuntimeError("Sensor not found. Check your wiring!")
+        for _ in range(2):  # Attempt to read twice.
+            self._uart.write(bytes([0x50]))
+            data = self._uart.read(1)  # 1 byte return for temp
+            if data:  # If there is a reading, exit the loop.
+                break
+            time.sleep(0.1)  # You need to wait between readings, so delay is included.
+        else:
+            # Loop exited normally, so read failed twice.
+            # This can happen when the object in front of the sensor is too close, if the wiring
+            # is incorrect or the sensor is not found.
+            return None
 
         if len(data) != 1:
-            raise RuntimeError("Did not receive temperature response")
+            return None
+
         temp = data[0] - 45
         return temp

--- a/adafruit_us100.py
+++ b/adafruit_us100.py
@@ -66,6 +66,7 @@ class US100:
         """
         for _ in range(2):  # Attempt to read twice.
             self._uart.write(bytes([0x55]))
+            time.sleep(0.1)
             data = self._uart.read(2)  # 2 byte return for distance.
             if data:  # If there is a reading, exit the loop.
                 break
@@ -87,6 +88,7 @@ class US100:
         """Return the on-chip temperature, in Celsius"""
         for _ in range(2):  # Attempt to read twice.
             self._uart.write(bytes([0x50]))
+            time.sleep(0.1)
             data = self._uart.read(1)  # 1 byte return for temp
             if data:  # If there is a reading, exit the loop.
                 break


### PR DESCRIPTION
The way I initially created this check was not sufficient. The current way it works, it fails with "Sensor not found" if you hold an object too close to the sensor. It turns out that UART will return `None` under multiple situations: no sensor found, wiring incorrect, object too close to sensor. I worked with @dhalbert to debug the issue and determined that simply checking for `if not data` was not robust enough. With Dan's help, we created a much more robust check that allows for a single failed read, includes a delay to handle the fact that the sensor can't handle quick successive reads, and instead of throwing an error, returns `None`. I also updated the `len(data) != 2` check to return None. This means in the event of that failure, the user would not need to include try/except code to have the sensor code continue running.

I was able to get the sensor to return `None` for `_uart.read` under all three listed situations: incorrect wiring, sensor not found and an object too close to the sensor. This is what triggered me requesting assistance to update the check because placing my hand over the sensor was triggering the current `RuntimeError: Sensor not found. Check wiring!`.

I was not however able to get the sensor to fail the `len(data) != 2` check by either moving it around very quickly, or pointing it at the sky with no object in front of it. Moving it around quickly returns various distances. Pointing it at the sky returned 1122.9 for distance, and did not fail. I can not verify that the explanation in the docstring for this check is accurate, but I did not remove it as it was included in the original. I simply updated it to explain that it returns `None`.

Fixed what I believe to be typo in the docstring - I believe it was meant to say the sensor can **not** detect objects over 460 cm away (the "datasheet" states max 450, so this approximately matches what I assume the docstring was meant to say).